### PR TITLE
fix: delay URL revoke after export

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -438,7 +438,7 @@ function Toolbar({ plan, setPlan }) {
     a.href = url;
     a.download = `${plan.meta.title.replace(/[^a-z0-9]+/gi, "-")}.json`;
     a.click();
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   };
 
   const importJSON = (file) => {


### PR DESCRIPTION
## Summary
- delay revocation of object URL during JSON export

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c765eac9b48324abc24309b89d11a0