### PR TITLE
Fix client export error by simplifying Babel setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,13 @@
     <meta charset="UTF-8" />
     <title>Democracy App</title>
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-    <script src="https://unpkg.com/systemjs/dist/system.min.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>
     <script
       type="text/babel"
-      data-presets="env,react"
+      data-presets="react"
       data-type="module"
       src="app.jsx"
     ></script>


### PR DESCRIPTION
## Summary
- Remove SystemJS loader and rely on ES modules
- Use only React preset so Babel doesn't emit CommonJS `exports`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c768dedec88324b52cea3d5a34c768