### PR TITLE
build: prepare local assets instead of CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -1,0 +1,1 @@
+// Compiled JavaScript goes here. Run `npm run build:js` to regenerate.

--- a/index.html
+++ b/index.html
@@ -3,17 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <title>Democracy App</title>
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-    <script src="https://unpkg.com/systemjs/dist/system.min.js"></script>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="styles.css" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>
-    <script
-      type="text/babel"
-      data-presets="env,react"
-      data-type="module"
-      src="app.jsx"
-    ></script>
+    <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "democracy",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build:js": "babel app.jsx --out-file app.js --presets @babel/preset-env,@babel/preset-react",
+    "build:css": "tailwindcss -i ./src/input.css -o ./styles.css --minify",
+    "build": "npm run build:js && npm run build:css",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.22.9",
+    "@babel/core": "^7.22.9",
+    "@babel/preset-env": "^7.22.9",
+    "@babel/preset-react": "^7.22.5",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.2"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/input.css
+++ b/src/input.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1 @@
+/* Compiled Tailwind CSS goes here. Run `npm run build:css` to regenerate. */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./app.jsx"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- drop in-browser Babel and Tailwind CDN from HTML
- add build configuration for Tailwind and Babel compilation

## Testing
- `npm run build` *(fails: babel not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7690d0a608324bfdf0a14b4f4ce42