### PR TITLE
Delay revoking object URL in export

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,7 +437,9 @@ function Toolbar({ plan, setPlan }) {
     a.href = url;
     a.download = `${plan.meta.title.replace(/[^a-z0-9]+/gi, "-")}.json`;
     a.click();
-    URL.revokeObjectURL(url);
+    // Delay revoking the object URL to ensure the download has been
+    // triggered across browsers before cleaning it up.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   };
 
   const importJSON = (file) => {


### PR DESCRIPTION
## Summary
- Delay URL.revokeObjectURL in `exportJSON` to ensure downloads complete before cleanup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c765b5d54c8324ae166768cf6841ce