### PR TITLE
fix: avoid export error in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build:js": "babel app.jsx --out-file app.js --presets @babel/preset-env,@babel/preset-react",
+    "build:js": "babel app.jsx --out-file app.js --presets @babel/preset-react",
     "build:css": "tailwindcss -i ./src/input.css -o ./styles.css --minify",
     "build": "npm run build:js && npm run build:css",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -12,7 +12,6 @@
   "devDependencies": {
     "@babel/cli": "^7.22.9",
     "@babel/core": "^7.22.9",
-    "@babel/preset-env": "^7.22.9",
     "@babel/preset-react": "^7.22.5",
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.24",


### PR DESCRIPTION
## Summary
- simplify Babel build to transpile JSX only
- drop unused preset-env dev dependency

## Testing
- `npm run build:js` *(fails: babel not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c76b8e75d48324b4412cca64398060