### PR TITLE
Load app directly in browser without build step

### DIFF
--- a/app.jsx
+++ b/app.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef, useState } from "https://esm.sh/react@18";
-import { createRoot } from "https://esm.sh/react-dom@18/client";
+const { useEffect, useMemo, useRef, useState } = React;
+const { createRoot } = ReactDOM;
 
 // Year 9 Civics & Citizenship — Unit Plan (Single-file React app)
 // Designed for quick editing, printing, export/import (JSON), and ACARA/SA alignment viewing.

--- a/index.html
+++ b/index.html
@@ -3,10 +3,13 @@
   <head>
     <meta charset="UTF-8" />
     <title>Democracy App</title>
-    <link href="styles.css" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="app.js"></script>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" data-presets="react" src="app.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Tailwind, React, and ReactDOM from CDNs and compile JSX in-browser with Babel so the app displays without running a build step.
- Drop local imports in `app.jsx` and rely on CDN-provided globals.

## Testing
- `npm run build` *(fails: babel not found)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c76cd184b883249035be97c26b3641