### PR TITLE
Enhance PillToggle accessibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -257,11 +257,14 @@ function PillToggle({
   onChange
 }) {
   return /*#__PURE__*/React.createElement("div", {
-    className: "inline-flex rounded-2xl border border-slate-300 bg-slate-100 p-1"
+    className: "inline-flex rounded-2xl border border-slate-300 bg-slate-100 p-1",
+    role: "group"
   }, options.map(opt => /*#__PURE__*/React.createElement("button", {
     key: opt,
     className: classNames("px-3 py-1.5 text-sm rounded-xl", value === opt ? "bg-white shadow font-semibold" : "text-slate-600"),
-    onClick: () => onChange(opt)
+    onClick: () => onChange(opt),
+    "aria-pressed": value === opt,
+    "aria-label": opt
   }, opt)));
 }
 function EditableList({

--- a/app.jsx
+++ b/app.jsx
@@ -329,7 +329,10 @@ function Badge({ children }) {
 
 function PillToggle({ options, value, onChange }) {
   return (
-    <div className="inline-flex rounded-2xl border border-slate-300 bg-slate-100 p-1">
+    <div
+      className="inline-flex rounded-2xl border border-slate-300 bg-slate-100 p-1"
+      role="group"
+    >
       {options.map((opt) => (
         <button
           key={opt}
@@ -338,6 +341,8 @@ function PillToggle({ options, value, onChange }) {
             value === opt ? "bg-white shadow font-semibold" : "text-slate-600"
           )}
           onClick={() => onChange(opt)}
+          aria-pressed={value === opt}
+          aria-label={opt}
         >
           {opt}
         </button>


### PR DESCRIPTION
## Summary
- add `role="group"` to PillToggle container
- mark each button with `aria-pressed` state and an `aria-label`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68c7cba4ccd48327901631876e3eab20